### PR TITLE
Local docker dev speedup and simplification

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -29,22 +29,24 @@ $ git submodule update --remote
 
 ### Building local changes
 1. First, be sure that you have first followed the [installation documentation](https://github.com/lyft/amundsen/blob/master/docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) and can spin up a default version of Amundsen without any issues. If you have already completed this step, be sure to have stopped and removed those containers by running:
-```bash
-$ docker-compose -f docker-amundsen.yml down
-```
-2. Launch the containers needed for local development by running:
-```bash
-$ docker-compose -f docker-amundsen-local.yml up
-```
-3. After making local changes rebuild the containers for any submodule that was modified. For example, to build a local change in `amundsen/amundsenmetadatalibrary` run:
-```bash
-$ docker-compose -f docker-amundsen-local.yml build amundsenmetadata
-```
-4. Relaunch the services by running:
-```bash
-$ docker-compose -f docker-amundsen-local.yml stop
-$ docker-compose -f docker-amundsen-local.yml up
-```
+    ```bash
+    $ docker-compose -f docker-amundsen.yml down
+    ```
+2. Launch the containers needed for local development (the `-d` option launches in background) :
+    ```bash
+    $ docker-compose -f docker-amundsen-local.yml up -d
+    ```
+3. After making local changes rebuild and relaunch modified containers:
+    ```bash
+    $ docker-compose -f docker-amundsen-local.yml build \
+      && docker-compose -f docker-amundsen-local.yml up -d
+    ```
+4. Optionally, to still tail logs, in a different terminal you can:
+    ```bash
+    $ docker-compose -f docker-amundsen-local.yml logs --tail=3 -f
+    ## - or just tail single container(s):
+    $ docker logs amundsenmetadata --tail 10 -f
+    ```
 
 ### Troubleshooting
 1. If you have made a change in `amundsen/amundsenfrontendlibrary` and do not see your changes, this could be due to your browser's caching behaviors. Either execute a hard refresh (recommended) or clear your browser cache (last resort).


### PR DESCRIPTION
### Summary of Changes

Cut some time and things to handle in your head/keystrokes away:
* Little need to limit the build to single containers. Due to docker caching additional build time is negligible. 
* No need to `stop` as part of compose relaunch, `up` will detect changed containers and only relaunch as needed
* Also, indent code snippets in the numbered steps

### Documentation

yep!

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely.
- [x] PR includes a summary of changes.
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
