### PR TITLE
Adding resources, tolerations, node selectors, and affinities to the helm charts

### DIFF
--- a/amundsen-kube-helm/templates/helm/amundsen/Chart.yaml
+++ b/amundsen-kube-helm/templates/helm/amundsen/Chart.yaml
@@ -1,2 +1,3 @@
 name: amundsen
+version: 0.0.1
 home: https://github.com/lyft/amundsen

--- a/amundsen-kube-helm/templates/helm/amundsen/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/amundsen/templates/deployment.yaml
@@ -7,12 +7,24 @@ spec:
   selector:
     matchLabels:
       run: {{ .Chart.Name }}-{{ .Values.searchServiceName }}
-  replicas: 1
+  replicas: {{ default 1 .Values.search.replicas }}
   template:
     metadata:
       labels:
         run: {{ .Chart.Name }}-{{ .Values.searchServiceName }}
     spec:
+      {{- with default .Values.nodeSelector .Values.search.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.affinity .Values.search.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.tolerations .Values.search.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-{{ .Values.searchServiceName }}
         image: {{- if .Values.searchServiceImage }} {{.Values.searchServiceImage}}{{- else }} {{ .Values.dockerhubImagePath }}/{{ .Chart.Name }}-{{ .Values.searchServiceName }}:{{ .Values.searchImageVersion }}{{- end }}
@@ -21,6 +33,10 @@ spec:
         env:
         - name: PROXY_ENDPOINT
           value: elasticsearch  
+        {{- with .Values.search.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,12 +46,24 @@ spec:
   selector:
     matchLabels:
       run: {{ .Chart.Name }}-{{ .Values.metadataServiceName }}
-  replicas: 1
+  replicas: {{ default 1 .Values.metadataReplicas }}
   template:
     metadata:
       labels:
         run: {{ .Chart.Name }}-{{ .Values.metadataServiceName }}
     spec:
+      {{- with default .Values.nodeSelector .Values.metadata.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.affinity .Values.metadata.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.tolerations .Values.metadata.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-{{ .Values.metadataServiceName }}
         image: {{- if .Values.metadataServiceImage }} {{.Values.metadataServiceImage}}{{- else }} {{ .Values.dockerhubImagePath }}/{{ .Chart.Name }}-{{ .Values.metadataServiceName }}:{{ .Values.metadataImageVersion }}{{- end }}
@@ -44,6 +72,10 @@ spec:
         env:
         - name: PROXY_HOST
           value: bolt://neo4j
+        {{- with .Values.metadata.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -53,12 +85,24 @@ spec:
   selector:
     matchLabels:
       run: {{ .Chart.Name }}-{{ .Values.frontEndServiceName }}
-  replicas: 1
+  replicas: {{ default 1 .Values.frontEnd.replicas }}
   template:
     metadata:
       labels:
         run: {{ .Chart.Name }}-{{ .Values.frontEndServiceName }}
     spec:
+      {{- with default .Values.nodeSelector .Values.frontEnd.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.affinity .Values.frontEnd.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with default .Values.tolerations .Values.frontEnd.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-{{ .Values.frontEndServiceName }}
         image: {{- if .Values.frontEndServiceImage }} {{.Values.frontEndServiceImage}}{{- else }} {{ .Values.dockerhubImagePath }}/{{ .Chart.Name }}-{{ .Values.frontEndServiceName }}:{{ .Values.frontEndImageVersion }}{{- end }}

--- a/amundsen-kube-helm/templates/helm/amundsen/values.yaml
+++ b/amundsen-kube-helm/templates/helm/amundsen/values.yaml
@@ -1,0 +1,60 @@
+environment: "dev"
+provider: aws
+dnsZone: teamname.company.com
+dockerhubImagePath: amundsendev
+
+## Support Node, affinity and tolerations for scheduler pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
+searchServiceName: search
+searchImageVersion: 1.4.0
+search:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+metadataServiceName: metadata
+metadataImageVersion: 1.1.1
+metadata:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  # You can also set these properties to override the ones set above
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+frontEndServiceName: frontend
+frontEndImageVersion: 1.0.9
+frontEndServicePort: 80
+frontEnd:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  # You can also set these properties to override the ones set above
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []

--- a/amundsen-kube-helm/templates/helm/elasticsearch/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/elasticsearch/templates/deployment.yaml
@@ -12,8 +12,24 @@ spec:
       labels:
         run: {{ .Chart.Name }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Chart.Name }}:{{ .Chart.AppVersion }}
         ports:
         - containerPort: 9200  
+        {{- with .Values.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}

--- a/amundsen-kube-helm/templates/helm/elasticsearch/values.yaml
+++ b/amundsen-kube-helm/templates/helm/elasticsearch/values.yaml
@@ -1,0 +1,15 @@
+provider: aws
+# nodeSelector 
+# affinity 
+# tolerations 
+# resources
+# annotations 
+environment: staging
+dnsZone: teamname.company.com
+resources:
+  limits:
+    cpu: 2
+    memory: 2Gi
+  requests:
+    cpu: 1
+    memory: 1Gi

--- a/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
@@ -12,6 +12,18 @@ spec:
       labels:
         run: {{ .Chart.Name }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Chart.Name }}:{{ .Chart.AppVersion }}
@@ -30,3 +42,7 @@ spec:
         - name: conf
           configMap:
             name: {{ .Chart.Name }}-configmap
+      {{- with .Values.resources }}
+      resources:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/amundsen-kube-helm/templates/helm/neo4j/values.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/values.yaml
@@ -1,0 +1,15 @@
+provider: aws
+# nodeSelector 
+# affinity 
+# tolerations 
+# resources
+# annotations 
+environment: staging
+dnsZone: teamname.company.com
+resources:
+  limits:
+    cpu: 2
+    memory: 2Gi
+  requests:
+    cpu: 1
+    memory: 1Gi


### PR DESCRIPTION
I have added resources, tolerations, node selectors, and affinities to the helm charts. We need these to deploy to our kubernetes cluster. I also added some default value files to charts. 