### PR TITLE
Improve flexibility & user-friendliness of helm deployment

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -19,11 +19,11 @@ provider: aws
 dnsZone: teamname.company.com
 dockerhubImagePath: amundsendev
 searchServiceName: search
-searchImageVersion: 1.4.0
+searchImageVersion: 1.4.2
 metadataServiceName: metadata
-metadataImageVersion: 1.1.1
+metadataImageVersion: 1.1.5
 frontEndServiceName: frontend
-frontEndImageVersion: 1.0.9
+frontEndImageVersion: 1.1.1
 frontEndServicePort: 80
 ```
 

--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -27,6 +27,15 @@ frontEndImageVersion: 1.0.9
 frontEndServicePort: 80
 ```
 
+You may want to override the default memory usage for Neo4J. In particular, if you're just test-driving a deployment and your node exits with status 137, you should set the usage to smaller values:
+```
+config:
+  dbms:
+    heap_initial_size: 2Gi
+    heap_max_size: 2Gi
+    pagecache_size: 2Gi
+```
+
 With this values file, you can then setup amundsen with these commands:
 ```
 helm install templates/helm/neo4j --values impl/helm/dev/values.yaml

--- a/amundsen-kube-helm/templates/helm/amundsen/values.yaml
+++ b/amundsen-kube-helm/templates/helm/amundsen/values.yaml
@@ -12,7 +12,7 @@ affinity: {}
 tolerations: []
 
 searchServiceName: search
-searchImageVersion: 1.4.0
+searchImageVersion: 1.4.2
 search:
   replicas: 1
   resources:
@@ -27,7 +27,7 @@ search:
   tolerations: []
 
 metadataServiceName: metadata
-metadataImageVersion: 1.1.1
+metadataImageVersion: 1.1.5
 metadata:
   replicas: 1
   resources:
@@ -43,7 +43,7 @@ metadata:
   tolerations: []
 
 frontEndServiceName: frontend
-frontEndImageVersion: 1.0.9
+frontEndImageVersion: 1.1.1
 frontEndServicePort: 80
 frontEnd:
   replicas: 1

--- a/amundsen-kube-helm/templates/helm/elasticsearch/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/elasticsearch/templates/deployment.yaml
@@ -24,11 +24,17 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      initContainers:
+      - name: init-map-count
+        image: busybox:1.31
+        securityContext:
+          privileged: true
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.initContainer.vmMaxMapCount }}"]
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Chart.Name }}:{{ .Chart.AppVersion }}
         ports:
-        - containerPort: 9200  
+        - containerPort: 9200
         {{- with .Values.resources }}
         resources:
 {{ toYaml . | indent 10 }}

--- a/amundsen-kube-helm/templates/helm/elasticsearch/values.yaml
+++ b/amundsen-kube-helm/templates/helm/elasticsearch/values.yaml
@@ -1,11 +1,13 @@
 provider: aws
-# nodeSelector 
-# affinity 
-# tolerations 
+# nodeSelector
+# affinity
+# tolerations
 # resources
-# annotations 
+# annotations
 environment: staging
 dnsZone: teamname.company.com
+initContainer:
+  vmMaxMapCount: 262144
 resources:
   limits:
     cpu: 2

--- a/amundsen-kube-helm/templates/helm/neo4j/templates/configmap.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/configmap.yaml
@@ -21,11 +21,11 @@ data:
     dbms.logs.query.enabled=true
     dbms.logs.query.rotation.keep_number=7
     dbms.logs.query.rotation.size=20m
-    dbms.memory.heap.initial_size=23000m
-    dbms.memory.heap.max_size=23000m
-    dbms.memory.pagecache.size=26600m
+    dbms.memory.heap.initial_size={{ .Values.config.dbms.heap_initial_size }}
+    dbms.memory.heap.max_size={{ .Values.config.dbms.heap_max_size }}
+    dbms.memory.pagecache.size={{ .Values.config.dbms.pagecache_size }}
     dbms.security.allow_csv_import_from_file_urls=true
     dbms.security.procedures.unrestricted=algo.*,apoc.*
-    dbms.windows_service_name=neo4j  
+    dbms.windows_service_name=neo4j
     apoc.export.file.enabled=true
     apoc.import.file.enabled=true

--- a/amundsen-kube-helm/templates/helm/neo4j/values.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/values.yaml
@@ -1,9 +1,9 @@
 provider: aws
-# nodeSelector 
-# affinity 
-# tolerations 
+# nodeSelector
+# affinity
+# tolerations
 # resources
-# annotations 
+# annotations
 environment: staging
 dnsZone: teamname.company.com
 resources:
@@ -13,3 +13,8 @@ resources:
   requests:
     cpu: 1
     memory: 1Gi
+config:
+  dbms:
+    heap_initial_size: 23000m
+    heap_max_size: 23000m
+    pagecache_size: 26600m


### PR DESCRIPTION
### Summary of Changes

This updates the helm templates & docs to make deployments work better out-of-the box for first-time users.

1. Uses latest amundsen versions to fix issues saving tags/descriptions
2. Increases the `vm.max_map_count` from an initContainer so that ES doesn't exit on startup
    - This approach is similar to that used by the official Helm chart
3. Makes Neo4j memory settings (heap & page cache) configurable, and recommends smaller values for test setups

These are the steps I needed to get Amundsen running on a fresh 3-node EKS cluster with m5.large instances.

cc @jornh @javamonkey79

### Documentation

I documented how to configure Neo4j memory settings and added smaller example settings than the existing defaults.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
