### PR TITLE
setting up a pvc to allow for neo4j backups

### DIFF
--- a/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
@@ -38,15 +38,19 @@ spec:
         volumeMounts:
         - name: conf
           mountPath: /conf
+        {{- if (or (kindIs "invalid" .Values.neo4jpvc) .Values.neo4jpvc)}}
         - name: data
           mountPath: /var/lib/neo4j/data
+        {{- end}}
       volumes:
         - name: conf
           configMap:
             name: {{ .Chart.Name }}-configmap
+        {{- if (or (kindIs "invalid" .Values.neo4jpvc) .Values.neo4jpvc)}}
         - name: data
           persistentVolumeClaim:
             claimName: neo4j-pvc
+        {{- end}}
       {{- with .Values.resources }}
       resources:
 {{ toYaml . | indent 8 }}

--- a/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/deployment.yaml
@@ -37,11 +37,16 @@ spec:
             value: "/conf"
         volumeMounts:
         - name: conf
-          mountPath: /conf                 
+          mountPath: /conf
+        - name: data
+          mountPath: /var/lib/neo4j/data
       volumes:
         - name: conf
           configMap:
             name: {{ .Chart.Name }}-configmap
+        - name: data
+          persistentVolumeClaim:
+            claimName: neo4j-pvc
       {{- with .Values.resources }}
       resources:
 {{ toYaml . | indent 8 }}

--- a/amundsen-kube-helm/templates/helm/neo4j/templates/pvc.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/pvc.yaml
@@ -1,0 +1,26 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+    name: neo4j-pv
+    labels:
+        type: local
+spec:
+    storageClassName: manual
+    capacity:
+        storage: 3Gi
+    accessModes:
+        - ReadWriteMany
+    hostPath:
+        path: "/mnt/ephemeral/neo4j/data"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: neo4j-pvc
+spec:
+    storageClassName: manual
+    accessModes:
+        - ReadWriteMany
+    resources:
+        requests:
+            storage: 3Gi

--- a/amundsen-kube-helm/templates/helm/neo4j/templates/pvc.yaml
+++ b/amundsen-kube-helm/templates/helm/neo4j/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if (or (kindIs "invalid" .Values.neo4jpvc) .Values.neo4jpvc)}}
 kind: PersistentVolume
 apiVersion: v1
 metadata:
@@ -7,7 +8,7 @@ metadata:
 spec:
     storageClassName: manual
     capacity:
-        storage: 3Gi
+        storage: {{ default "3Gi" .Values.neo4jpvcSize }}
     accessModes:
         - ReadWriteMany
     hostPath:
@@ -23,4 +24,5 @@ spec:
         - ReadWriteMany
     resources:
         requests:
-            storage: 3Gi
+            storage: {{ default "3Gi" .Values.neo4jpvcSize }}
+{{- end -}}


### PR DESCRIPTION
### Summary of Changes

* In order to allow other pods to access neo4j disk, we need to setup a pvc and point neo4j at it


### Documentation

* No doc changes

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
