### PR TITLE
Persist data locally when running docker-amundsen-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 example/backup/
 example/docker/neo4j/plugins/
 example/docker/es_data*
+.local/
 
 .idea/
+!.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ example/docker/es_data*
 .local/
 
 .idea/
-!.gitkeep

--- a/docker-amundsen-local.yml
+++ b/docker-amundsen-local.yml
@@ -14,6 +14,7 @@ services:
           - 7687:7687
       volumes:
           - ./example/docker/neo4j/conf:/conf
+          - ./.local/neo4j/data:/neo4j/data
       networks:
         - amundsennet
   elasticsearch:
@@ -23,6 +24,8 @@ services:
           - 9200:9200
       networks:
         - amundsennet
+      volumes:
+        - ./.local/elasticsearch/data:/usr/share/elasticsearch/data
   amundsensearch:
       build:
         context: ./amundsensearchlibrary

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -48,5 +48,18 @@ $ git submodule update --remote
     $ docker logs amundsenmetadata --tail 10 -f
     ```
 
+### Local data
+
+Local data is persisted under [.local/](../.local/), clean up those directories to reset the databases
+
+```bash
+#  reset elasticsearch
+rm -rf .local/elasticsearch
+
+#  reset neo4j
+rm -rf .local/neo4j
+```
+
+
 ### Troubleshooting
 1. If you have made a change in `amundsen/amundsenfrontendlibrary` and do not see your changes, this could be due to your browser's caching behaviors. Either execute a hard refresh (recommended) or clear your browser cache (last resort).

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -50,7 +50,7 @@ $ git submodule update --remote
 
 ### Local data
 
-Local data is persisted under [.local/](../.local/), clean up those directories to reset the databases
+Local data is persisted under .local/ (at the root of the project), clean up the following directories to reset the databases:
 
 ```bash
 #  reset elasticsearch


### PR DESCRIPTION
### Summary of Changes

I would like to persist the elasticsearch and neo4j data locally when developing using docker-amundsen-local

This is mainly so `docker-compose -f docker-amundsen-local.yml down` becomes safe to run without destroying local data


### Documentation

I updated the developer guide to include a note to remove the neo4j / elasticsearch files in order to clean up their states

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
