### PR TITLE
Add ulimits to elasticsearch.

### DIFF
--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -29,6 +29,10 @@ services:
 #          - ./example/docker/es_data:/usr/share/elasticsearch/data
       networks:
         - amundsennet
+      ulimits:
+        nofile:
+          soft: 65536
+          hard: 65536
   amundsensearch:
       image: amundsendev/amundsen-search:1.4.1
       container_name: amundsensearch


### PR DESCRIPTION
### Summary of Changes

Addressing this:
https://github.com/lyft/amundsen/issues/247

Explicitly setting the ulimits in the docker-compose file fixes the above problem (`max file descriptors is too low`).


### Documentation

<!-- _What documentation did you add or modify and why? Add any relevant links then optionally, remove this line_ -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
