### PR TITLE
Fix a badge to be https and change color

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   width="500"
 />
 
-[![License](http://img.shields.io/:license-Apache%202-blue.svg)](LICENSE)
+[![License](https://img.shields.io/:license-Apache%202-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 [![Commit activity](https://img.shields.io/github/commit-activity/w/lyft/amundsen.svg?style=plastic)](https://img.shields.io/github/commit-activity/w/lyft/amundsen.svg?style=plastic)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/amundsenworkspace/shared_invite/enQtNTk2ODQ1NDU1NDI0LTc3MzQyZmM0ZGFjNzg5MzY1MzJlZTg4YjQ4YTU0ZmMxYWU2MmVlMzhhY2MzMTc1MDg0MzRjNTA4MzRkMGE0Nzk)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ theme:
   logo: img/logos/amundsen_mark_orange.svg
   favicon: 'img/logos/amundsen_mark_orange.svg'
   palette:
-    primary: 'blue'
-    accent: 'pink'
+    primary: 'deep purple'
+    accent: 'deep orange'
   feature:
     tabs: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ theme:
   logo: img/logos/amundsen_mark_orange.svg
   favicon: 'img/logos/amundsen_mark_orange.svg'
   palette:
-    primary: 'deep purple'
-    accent: 'deep orange'
+    primary: '#2B1B81'
+    accent: '#2B1B81'
   feature:
     tabs: true
 


### PR DESCRIPTION

### Summary of Changes

<img width="1366" alt="Screen Shot 2020-04-17 at 4 36 31 PM" src="https://user-images.githubusercontent.com/3223098/79621828-a8fa9e00-80c9-11ea-8687-a3f533ad0335.png">

All the supported color could be found at https://www.materialui.co/colors . Felt the new one looks better, but ok to not change.

Also fix a badge link to be https


### Documentation

<!-- _What documentation did you add or modify and why? Add any relevant links then optionally, remove this line_ -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely.
- [ ] PR includes a summary of changes.
- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
