### PR TITLE
Fixup Neo4j pod OOM by adjust DBMS config

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -110,9 +110,9 @@ You may want to override the default memory usage for Neo4J. In particular, if y
 ```
 config:
   dbms:
-    heap_initial_size: 2Gi
-    heap_max_size: 2Gi
-    pagecache_size: 2Gi
+    heap_initial_size: 1G
+    heap_max_size: 2G
+    pagecache_size: 2G
 ```
 
 With this values file, you can then install Amundsen using Helm 2 with:

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -289,11 +289,11 @@ neo4j:
     ##
     dbms:
       ## neo4j.config.dbms.heap_initial_size -- the initial java heap for neo4j
-      heap_initial_size: 23000m
+      heap_initial_size: 1G
       ## neo4j.config.dbms.heap_max_size -- the max java heap for neo4j
-      heap_max_size: 23000m
+      heap_max_size: 2G
       ## neo4j.config.dbms.pagecache_size -- the page cache size for neo4j
-      pagecache_size: 26600m
+      pagecache_size: 2G
 
   ##
   ## neo4j.persistence -- Neo4j persistence. Turn this on to keep your data between pod crashes, etc. This is also needed for backups.


### PR DESCRIPTION
### Summary of Changes
The DBMS settings `23000m` cause Neo4j pod OOM, because it didn't a valid value for Neo4j.
It will be fix by change unit. e.g `2G`
<!-- _Include a summary of changes then, optionally, remove this line_ -->


### Documentation

<!-- _What documentation did you add or modify and why? Add any relevant links then optionally, remove this line_ -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
