### PR TITLE
User profiles tutorial

### DIFF
--- a/docs/tutorials/user-profiles.md
+++ b/docs/tutorials/user-profiles.md
@@ -1,0 +1,20 @@
+
+## People resources 
+
+### What can I do with User Resources? 
+User profile pages and the ability to bookmark/favorite and search for users is also available as of now. See a demo of what they feels like from an end user viewpoint from around the 36 minute mark of [this September 2019 talk](https://youtu.be/Gr3-RfWn49A?t=36m00s) - so you could actually argue that this video snippet can work as the user guide :smiley:
+
+### How do I enable User pages?
+
+The configuration to have `Users` available consists of:
+
+1. Enable the feature by performing [this frontend configuration]( https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/application_config.md#index-users)
+
+2. There are two different alternative ways to populate user profile data. You can either:
+   * Configure the Metadata service to a do a [live lookup](https://github.com/lyft/amundsenmetadatalibrary/blob/master/docs/configurations.md#user_detail_method-optional) in some directory service, like LDAP or a HR system.
+   * Setup ongoing ingest of user profile data as they onboard/change/offboard into Neo4j and Elasticsearch effectively caching it with the pros/cons of that (similar to what the Databuilder sample loader does from user CSV, see the “pre-cooked demo data” link in [the Architecture overview](https://github.com/lyft/amundsen/blob/master/docs/architecture.md#databuilder)
+
+   For both of these options, currently Amundsen only provides these hooks/interfaces to add your own implementation. If you build something you think is generally useful, contributions are welcome!
+
+3. Configure login, according to the [Authentication guide](https://github.com/lyft/amundsen/tree/master/docs/authentication)
+

--- a/docs/tutorials/user-profiles.md
+++ b/docs/tutorials/user-profiles.md
@@ -2,19 +2,22 @@
 ## People resources 
 
 ### What can I do with User Resources? 
-User profile pages and the ability to bookmark/favorite and search for users is also available as of now. See a demo of what they feels like from an end user viewpoint from around the 36 minute mark of [this September 2019 talk](https://youtu.be/Gr3-RfWn49A?t=36m00s) - so you could actually argue that this video snippet can work as the user guide :smiley:
+User profile pages and the ability to bookmark/favorite and search for users is also available as of now. See a demo of what they feels like from an end user viewpoint from around the 36 minute mark of [this September 2019 talk](https://youtu.be/Gr3-RfWn49A?t=36m00s) - so you could actually argue that this video snippet can work as an end user guide.
 
 ### How do I enable User pages?
 
 The configuration to have `Users` available consists of:
 
-1. Enable the feature by performing [this frontend configuration]( https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/application_config.md#index-users)
+1. Enable the users profile page index and display feature by performing [this frontend configuration](../../frontend/docs/application_config#index-users)
 
 2. There are two different alternative ways to populate user profile data. You can either:
-   * Configure the Metadata service to a do a [live lookup](https://github.com/lyft/amundsenmetadatalibrary/blob/master/docs/configurations.md#user_detail_method-optional) in some directory service, like LDAP or a HR system.
-   * Setup ongoing ingest of user profile data as they onboard/change/offboard into Neo4j and Elasticsearch effectively caching it with the pros/cons of that (similar to what the Databuilder sample loader does from user CSV, see the “pre-cooked demo data” link in [the Architecture overview](https://github.com/lyft/amundsen/blob/master/docs/architecture.md#databuilder)
 
-   For both of these options, currently Amundsen only provides these hooks/interfaces to add your own implementation. If you build something you think is generally useful, contributions are welcome!
+    * Configure the Metadata service to a do a [live lookup](../../metadata/docs/configurations#user_detail_method-optional) in some directory service, like LDAP or a HR system.
 
-3. Configure login, according to the [Authentication guide](https://github.com/lyft/amundsen/tree/master/docs/authentication)
+    * Setup ongoing ingest of user profile data as they onboard/change/offboard into Neo4j and Elasticsearch effectively caching it with the pros/cons of that (similar to what the Databuilder sample loader does from user CSV, see the “pre-cooked demo data” link in the [Architecture overview](../../architecture#databuilder)
+
+    !!! note
+        Currently, for both of these options Amundsen _only_ provides these hooks/interfaces to add your own implementation. If you build something you think is generally useful, contributions are welcome!
+
+3. Configure login, according to the [Authentication guide](../../authentication/oidc)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - 'Tutorials':
         - 'How to index the postgres database metadata': 'tutorials/index-postgres.md'
         - 'How to setup a preview client with Apache Superset': 'tutorials/data-preview-with-superset.md'
+        - 'How to setup user profiles': 'tutorials/user-profiles.md'
     - 'Deployment':
       - 'Authentication': 'authentication/oidc.md'
       - 'AWS ECS Installation': 'installation-aws-ecs/aws-ecs-deployment.md'


### PR DESCRIPTION
### Summary of Changes

<!-- _Include a summary of changes then, optionally, remove this line_ -->
Add a brief tutorial on configuring "all things people" namely user profiles and authentication.

### Documentation

<!-- _What documentation did you add or modify and why? Add any relevant links then optionally, remove this line_ -->

Based on part of a Slack thread https://amundsenworkspace.slack.com/archives/CGFBVT23V/p1585925405270300?thread_ts=1585857717.224700&cid=CGFBVT23V

> Note I made and tested the links with `mkdocs serve` so they should work when published to the docs site. Not sure if there's a way to have it working fully across both that and locally/when browsed directly in the GitHub repo.?