### PR TITLE
fix: Bump elasticsearch chart version from 1.24.0 to 1.32.4

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -20,7 +20,7 @@ This is setup templates for deploying [amundsen](https://github.com/lyft/amundse
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://kubernetes-charts.storage.googleapis.com/ | elasticsearch | 1.24.0 |
+| https://kubernetes-charts.storage.googleapis.com/ | elasticsearch | 1.32.0 |
 
 ## Chart Values
 The following table lists the configurable parameters of the Amundsen charts and their default values.

--- a/amundsen-kube-helm/templates/helm/requirements.yaml
+++ b/amundsen-kube-helm/templates/helm/requirements.yaml
@@ -3,6 +3,6 @@ dependencies:
 #    version: 1.2.2
 #    repository: https://kubernetes-charts.storage.googleapis.com/
   - name: elasticsearch
-    version: 1.24.0
+    version: 1.32.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: elasticsearch.enabled


### PR DESCRIPTION
<!--- 
Provide a general summary of your changes in the Title above 
Include a prefix to the title, one of build|ci|docs|feat|fix|perf|refactor|style|test|chore|other followed by a colon. 
Example: docs: Improves the documentation on...
-->
### Summary of Changes
<!-- Include a summary of changes -->
Currently when you run 
```bash
helm install amundsen amundsen-kube-helm/templates/helm
```

You get an error like this
```
Error: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "Deployment" in version "apps/v1beta1", unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta1"]
```

This was caused by elasticsearch's Helm Chart version `1.24.0`. Bumping it to the latest version, which is `1.32.0`, solved the issue.


### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links -->
Updated `amundsen-kube-helm/README.md` to reflect elasticsearch's version.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
