### PR TITLE
chore: Updated the deployment search file with Release.Name instead of Release.Namespace

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
@@ -46,7 +46,7 @@ spec:
         - containerPort: 5001
         env:
         - name: PROXY_ENDPOINT
-          value: {{ if .Values.search.elasticsearchEndpoint }}{{ .Values.search.elasticsearchEndpoint }}{{ else }}{{ .Release.Namespace }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+          value: {{ if .Values.search.elasticsearchEndpoint }}{{ .Values.search.elasticsearchEndpoint }}{{ else }}{{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
         livenessProbe:
           httpGet:
             path: "/healthcheck"


### PR DESCRIPTION
Check this issue : #486

Issue
Following https://github.com/lyft/amundsen/tree/master/amundsen-kube-helm to install amundsen to kube using helm 3. Using the default values without providing the ES endpoint in the values.yaml, it search service uses {{ .Release.Namespace }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local as the url to connect to ES. It gives error as it does not find this service. It should be Release.Name in the beginning of the url to connect

Summary of Changes
Replaced {{ .Release.Namespace }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local with {{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local

Documentation
NA