### PR TITLE
fix: update helm chart to prevent installation of elastic search resources when it's disabled

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.elasticsearch.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -60,3 +61,4 @@ spec:
         resources:
 {{ toYaml . | indent 10 }}
         {{- end }}
+{{-end }}

--- a/amundsen-kube-helm/templates/helm/templates/service-search.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/service-search.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.elasticsearch.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -24,3 +25,4 @@ spec:
     - name: {{ .Chart.Name }}-{{ .Values.search.serviceName }}-{{ .Values.environment }}-http
       port: 5001
       targetPort: 5001
+{{-end }}


### PR DESCRIPTION
Currently the property elasticsearch.enabled is ignored so that the elastic search is always installed. I've added a checking for this property to the deployment and service templates so that it would be possible to use another elasticsearch installation without having to install a fresh one.